### PR TITLE
feat: add labs 3 and 4 for itpt01 subject and bump package version

### DIFF
--- a/app/(labs)/[subject]/[slug]/page.tsx
+++ b/app/(labs)/[subject]/[slug]/page.tsx
@@ -10,9 +10,10 @@ import {
   allItwst01s,
   allItwst02s,
 } from "content-collections"
+// fumadocs components
+import { Callout } from "fumadocs-ui/components/callout"
 import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock"
 import { File, Files, Folder } from "fumadocs-ui/components/files"
-// fumadocs components
 import { ImageZoom } from "fumadocs-ui/components/image-zoom"
 import { Tab, Tabs } from "fumadocs-ui/components/tabs"
 import { Plus } from "lucide-react"
@@ -102,6 +103,7 @@ export default async function Page({ params }: PageProps) {
           code={labItem.mdx}
           components={{
             ImageContainer,
+            Callout,
             FileCard,
             File,
             Folder,

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "fumadocs-ui": "^15.6.12",
         "lucide-react": "^0.485.0",
         "motion": "^12.7.2",
-        "next": "^15.4.6",
+        "next": "^15.5.2",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -236,25 +236,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.7", "", { "dependencies": { "@emnapi/core": "^1.3.1", "@emnapi/runtime": "^1.3.1", "@tybys/wasm-util": "^0.9.0" } }, "sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw=="],
 
-    "@next/env": ["@next/env@15.4.6", "", {}, "sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ=="],
+    "@next/env": ["@next/env@15.5.2", "", {}, "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.2.4", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-O8ScvKtnxkp8kL9TpJTTKnMqlkZnS+QxwoQnJwPGBxjBbzd6OVVPEJ5/pMNrktSyXQD/chEfzfFzYLM6JANOOQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-667R0RTP4DwxzmrqTs4Lr5dcEda9OxuZsVFsjVtxVMVhzSpo6nLclXejJVfQo2/g7/Z9qF3ETDmN3h65mTjpTQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-KMSFoistFkaiQYVQQnaU9MPWtp/3m0kn2Xed1Ces5ll+ag1+rlac20sxG+MqhH2qYWX1O2GFOATQXEyxKiIscg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-2DjnmR6JHK4X+dgTXt5/sOCu/7yPtqpYt8s8hLkHFK3MGkka2snTv3yRMdHvuRtJVkPwCGsvBSwmoQCHatauFQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-PnOx1YdO0W7m/HWFeYd2A6JtBO8O8Eb9h6nfJia2Dw1sRHoHpNf6lN1U4GKFRzRDBi9Nq2GrHk9PF3Vmwf7XVw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3j7SWDBS2Wov/L9q0mFJtEvQ5miIqfO4l7d2m9Mo06ddsgUK8gWfHGgbjdFlCp2Ek7MmMQZSxpGFqcC8zGh2AA=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.6", "", { "os": "win32", "cpu": "x64" }, "sha512-T4ufqnZ4u88ZheczkBTtOF+eKaM14V8kbjud/XrAakoM5DKQWjW09vD6B9fsdsWS2T7D5EY31hRHdta7QKWOng=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-W5VvyZHnxG/2ukhZF/9Ikdra5fdNftxI6ybeVKYvBPDtyx7x4jPPSNduUkfH5fo3zG0JQ0bPxgy41af2JX5D4Q=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1144,7 +1144,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@15.4.6", "", { "dependencies": { "@next/env": "15.4.6", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.6", "@next/swc-darwin-x64": "15.4.6", "@next/swc-linux-arm64-gnu": "15.4.6", "@next/swc-linux-arm64-musl": "15.4.6", "@next/swc-linux-x64-gnu": "15.4.6", "@next/swc-linux-x64-musl": "15.4.6", "@next/swc-win32-arm64-msvc": "15.4.6", "@next/swc-win32-x64-msvc": "15.4.6", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": "dist/bin/next" }, "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ=="],
+    "next": ["next@15.5.2", "", { "dependencies": { "@next/env": "15.5.2", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.2", "@next/swc-darwin-x64": "15.5.2", "@next/swc-linux-arm64-gnu": "15.5.2", "@next/swc-linux-arm64-musl": "15.5.2", "@next/swc-linux-x64-gnu": "15.5.2", "@next/swc-linux-x64-musl": "15.5.2", "@next/swc-win32-arm64-msvc": "15.5.2", "@next/swc-win32-x64-msvc": "15.5.2", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1532,45 +1532,15 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
-    "@mdx-js/mdx/source-map": ["source-map@0.7.4", "", {}, "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="],
-
-    "@radix-ui/react-accordion/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collapsible/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g=="],
-
-    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -1587,10 +1557,6 @@
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
-
-    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "estree-util-to-js/source-map": ["source-map@0.7.4", "", {}, "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1626,35 +1592,11 @@
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
-
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@radix-ui/react-accordion/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-collapsible/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popper/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/contents/itipt01/m-lab3.mdx
+++ b/contents/itipt01/m-lab3.mdx
@@ -1,0 +1,400 @@
+---
+title: Laboratory 3
+---
+
+### Instructions
+
+**Project Access:** [bit.ly/student_py](https://bit.ly/student_py)
+
+#### Group Formation
+
+1. Make a group with three (3) members
+2. Download the Project by scanning QR Code
+3. Add the following attributes to your CRUD OOP Project
+
+#### Required Attributes
+
+1. Email Address
+2. Home Address
+3. Date of Birth
+4. Course
+5. Phone Number
+
+#### Student CRUD Console App Features
+
+```console
+🎓 Student CRUD Console App 🎓
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. View Student
+5. Exit
+6. Select an option (1-5): 4
+
+Search Results:
+
+ID: 1, Name: Ronaldin Ramat, Age: 29
+```
+
+### Requirements
+
+1. Python
+2. MySQL Server via XAMPP (`pip install mysql-connector-python`)
+3. Text Editor (VSCode, PyCharm, etc.)
+
+### Code
+
+<Files className="mt-4">
+  <Folder name="student_crud" defaultOpen>
+    <File name="__init__.py" />
+    <File name="database.py" />
+    <File name="operations.py" />
+    <File name="student.py" />
+  </Folder>
+  <File name="main.py" />
+</Files>
+
+<Tabs items={["main.py", "database.py", "operations.py", "student.py"]}>
+<Tab value="main.py">
+```python title="main.py" lineNumbers
+from student_crud.student import Student
+from student_crud.operations import (
+    add_student,
+    update_student,
+    delete_student,
+    search_students,
+)
+
+print("\n🎓 Student CRUD Console App 🎓")
+while True:
+    print("\nMenu:")
+    print("1. Add Student")
+    print("2. Update Student")
+    print("3. Delete Student")
+    print("4. Search Students")
+    print("5. Exit")
+
+    choice = input("Select an option (1-5): ")
+
+    if choice == "1":
+        fname = input("First Name: ")
+        lname = input("Last Name: ")
+        age = int(input("Age: "))
+        email = input("Email Address: ")
+        home_address = input("Home Address: ")
+        date_of_birth = input("Date of Birth (YYYY-MM-DD): ")
+        course = input("Course: ")
+        phone_number = input("Phone Number (11 digits): ")[:11]
+        student = Student(
+            firstname=fname,
+            lastname=lname,
+            age=age,
+            email=email,
+            home_address=home_address,
+            date_of_birth=date_of_birth,
+            course=course,
+            phone_number=phone_number,
+        )
+        add_student(student)
+
+    elif choice == "2":
+        sid = int(input("Student ID to update: "))
+        fname = input("New First Name: ")
+        lname = input("New Last Name: ")
+        age = int(input("New Age: "))
+        email = input("New Email Address: ")
+        home_address = input("New Home Address: ")
+        date_of_birth = input("New Date of Birth (YYYY-MM-DD): ")
+        course = input("New Course: ")
+        phone_number = input("New Phone Number (11 digits): ")[:11]
+        student = Student(
+            firstname=fname,
+            lastname=lname,
+            age=age,
+            email=email,
+            home_address=home_address,
+            date_of_birth=date_of_birth,
+            course=course,
+            phone_number=phone_number,
+            studentid=sid,
+        )
+        update_student(student)
+
+    elif choice == "3":
+        sid = int(input("Enter Student ID to delete: "))
+        delete_student(sid)
+
+    elif choice == "4":
+        keyword = input("Enter name to search: ")
+        results = search_students(keyword)
+        if results:
+            print("\nSearch Results:")
+            for row in results:
+                print(
+                    f"""ID: {row[0]}
+Name: {row[1]} {row[2]}
+Age: {row[3]}
+Email: {row[4]}
+Address: {row[5]}
+Date of Birth: {row[6]}
+Course: {row[7]}
+Phone: {row[8]}\n
+------------------------"""
+                )
+        else:
+            print("No matching students found.")
+
+    elif choice == "5":
+        print("👋 Exiting the program.")
+        break
+    else:
+        print("❌ Invalid option. Try again.")
+```
+</Tab>
+<Tab value="database.py">
+```python title="database.py" lineNumbers
+import mysql.connector
+
+def connect():
+  try:
+    conn = mysql.connector.connect(host="localhost", user="root", password="")
+    cursor = conn.cursor()
+    cursor.execute("CREATE DATABASE IF NOT EXISTS student_db")
+    cursor.execute("USE student_db")
+    cursor.execute(
+      """
+      CREATE TABLE IF NOT EXISTS students (
+        studentid INT AUTO_INCREMENT PRIMARY KEY,
+        firstname VARCHAR(50),
+        lastname VARCHAR(50),
+        age TINYINT,
+        email VARCHAR(100),
+        home_address TEXT,
+        date_of_birth DATE,
+        course VARCHAR(100),
+        phone_number VARCHAR(11)
+      )
+    """
+    )
+    conn.commit()
+    return conn
+except mysql.connector.Error as err:
+    print("Database error:", err)
+    return None
+```
+</Tab>
+<Tab value="operations.py">
+```python title="operations.py" lineNumbers
+from student_crud.database import connect
+from student_crud.student import Student
+
+
+def add_student(student):
+  conn = connect()
+  if conn:
+    cursor = conn.cursor()
+    query = """INSERT INTO students 
+            (firstname, lastname, age, email, home_address, date_of_birth, course, phone_number) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)"""
+    cursor.execute(
+      query,
+      (
+        student.firstname,
+        student.lastname,
+        student.age,
+        student.email,
+        student.home_address,
+        student.date_of_birth,
+        student.course,
+        student.phone_number,
+      ),
+    )
+    conn.commit()
+    print("✅ Student added successfully!")
+    conn.close()
+
+
+def update_student(student):
+  conn = connect()
+  if conn:
+    cursor = conn.cursor()
+    query = """UPDATE students 
+            SET firstname=%s, lastname=%s, age=%s, email=%s, 
+                home_address=%s, date_of_birth=%s, course=%s, phone_number=%s 
+            WHERE studentid=%s"""
+    cursor.execute(
+      query,
+      (
+        student.firstname,
+        student.lastname,
+        student.age,
+        student.email,
+        student.home_address,
+        student.date_of_birth,
+        student.course,
+        student.phone_number,
+        student.studentid,
+      ),
+    )
+    conn.commit()
+    print("🔄 Student updated successfully!")
+    conn.close()
+
+
+def delete_student(studentid):
+  conn = connect()
+  if conn:
+    cursor = conn.cursor()
+    query = "DELETE FROM students WHERE studentid = %s"
+    cursor.execute(query, (studentid,))
+    conn.commit()
+    print("🗑️ Student deleted successfully!")
+    conn.close()
+
+
+def search_students(keyword):
+  conn = connect()
+  if conn:
+    cursor = conn.cursor()
+    query = "SELECT * FROM students WHERE firstname LIKE %s OR lastname LIKE %s"
+    wildcard = f"%{keyword}%"
+    cursor.execute(query, (wildcard, wildcard))
+    results = cursor.fetchall()
+    conn.close()
+    return results
+  return []
+```
+</Tab>
+<Tab value="student.py">
+```python title="student.py" lineNumbers
+class Student:
+  def __init__(
+    self,
+    firstname,
+    lastname,
+    age,
+    email,
+    home_address,
+    date_of_birth,
+    course,
+    phone_number,
+    studentid=None,
+  ):
+    self.studentid = studentid
+    self.firstname = firstname
+    self.lastname = lastname
+    self.age = age
+    self.email = email
+    self.home_address = home_address
+    self.date_of_birth = date_of_birth
+    self.course = course
+    self.phone_number = phone_number
+```
+</Tab>
+</Tabs>
+
+## Output
+
+```console
+🎓 Student CRUD Console App 🎓
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 1
+First Name: Cedric
+Last Name: Angulo
+Age: 21
+Email Address: cdrcangulo@gmail.com
+Home Address: Earth
+Date of Birth (YYYY-MM-DD): 2004-11-01
+Course: BSIT
+Phone Number (11 chars max): 09511703251
+✅ Student added successfully!
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 4
+Enter name to search: Ced
+
+Search Results:
+ID: 1
+Name: Cedric Angulo
+Age: 21
+Email: cdrcangulo@gmail.com
+Address: Earth
+Date of Birth: 2004-11-01
+Course: BSIT
+Phone: 09511703251
+
+------------------------
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 2
+Student ID to update: 1
+New First Name: Cedric Bryan
+New Last Name: Angulo
+New Age: 21
+New Email Address: cdrcangulo@gmail.com
+New Home Address: Uranus
+New Date of Birth (YYYY-MM-DD): 2001-9-11
+New Course: BSCS
+New Phone Number (09** *** ****): 09511703251
+🔄 Student updated successfully!
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 4
+Enter name to search: Bryan
+
+Search Results:
+ID: 1
+Name: Cedric Bryan Angulo
+Age: 21
+Email: cdrcangulo@gmail.com
+Address: Uranus
+Date of Birth: 2001-09-11
+Course: BSCS
+Phone: 09511703251
+
+------------------------
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 3
+Enter Student ID to delete: 1
+🗑️ Student deleted successfully!
+
+Menu:
+1. Add Student
+2. Update Student
+3. Delete Student
+4. Search Students
+5. Exit
+Select an option (1-5): 5
+👋 Exiting the program.
+```
+
+👽

--- a/contents/itipt01/m-lab4.mdx
+++ b/contents/itipt01/m-lab4.mdx
@@ -1,0 +1,335 @@
+---
+title: Laboratory 4
+---
+
+### Instructions
+
+**Project Access:** [bit.ly/python_gui-oop](https://bit.ly/python_gui-oop)
+
+#### Group Formation
+
+1. Make a group with three(3) members
+2. Download the source code by scanning QR Code
+3. Choose one (1) of the following attributes to be added in your CRUD OOP Project
+
+#### Required Attributes (Choose One)
+
+1. Email Address
+2. Home Address
+3. Date of Birth
+4. Course
+5. Phone Number
+
+### Code
+
+```python title="main.py"
+# Python Tkinter + MySQL App using OOP (Classes, Inheritance, Encapsulation, Polymorphism, Properties)
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+import mysql.connector
+
+
+# -----------------------------
+# Database Layer (Encapsulation)
+# -----------------------------
+class Database:
+    def __init__(self):
+        self._connection = None
+        self._connect()
+
+    def _connect(self):
+        try:
+            self._connection = mysql.connector.connect(
+                host="localhost", user="root", password=""
+            )
+            cursor = self._connection.cursor()
+            cursor.execute("CREATE DATABASE IF NOT EXISTS python_mysql")
+            cursor.execute("USE python_mysql")
+            cursor.execute(
+                """CREATE TABLE IF NOT EXISTS tblstudentinfo (
+                studentid INT PRIMARY KEY AUTO_INCREMENT,
+                lastname VARCHAR(50),
+                firstname VARCHAR(50),
+                sex CHAR(1),
+                contactnumber VARCHAR(15),
+                email VARCHAR(100))"""
+            )
+            self._connection.commit()
+        except mysql.connector.Error as err:
+            messagebox.showerror("Database Error", str(err))
+
+    @property
+    def connection(self):
+        return self._connection
+
+    def close(self):
+        if self._connection:
+            self._connection.close()
+
+
+# -----------------------------
+# Model: Student
+# -----------------------------
+class Student:
+    def __init__(
+        self,
+        studentid=None,
+        lastname="",
+        firstname="",
+        sex="",
+        contactnumber="",
+        email="",
+    ):
+        self.studentid = studentid
+        self.lastname = lastname
+        self.firstname = firstname
+        self.sex = sex
+        self.contactnumber = contactnumber
+        self.email = email
+
+
+# -----------------------------
+# Controller: Manages student operations
+# -----------------------------
+class StudentController:
+    def __init__(self, db: Database):
+        self.db = db
+
+    def add_student(self, student: Student):
+        if student.lastname and student.firstname and student.sex in ["M", "F"]:
+            cursor = self.db.connection.cursor()
+            query = "INSERT INTO tblstudentinfo (lastname, firstname, sex, contactnumber, email) VALUES (%s, %s, %s, %s, %s)"
+            cursor.execute(
+                query,
+                (
+                    student.lastname,
+                    student.firstname,
+                    student.sex,
+                    student.contactnumber,
+                    student.email,
+                ),
+            )
+            self.db.connection.commit()
+        else:
+            raise ValueError("Missing fields or invalid sex")
+
+    def update_student(self, student: Student):
+        if (
+            student.studentid
+            and student.lastname
+            and student.firstname
+            and student.sex in ["M", "F"]
+        ):
+            cursor = self.db.connection.cursor()
+            query = "UPDATE tblstudentinfo SET lastname=%s, firstname=%s, sex=%s, contactnumber=%s, email=%s WHERE studentid=%s"
+            cursor.execute(
+                query,
+                (
+                    student.lastname,
+                    student.firstname,
+                    student.sex,
+                    student.contactnumber,
+                    student.email,
+                    student.studentid,
+                ),
+            )
+            self.db.connection.commit()
+        else:
+            raise ValueError("Incomplete data for update")
+
+    def delete_student(self, studentid):
+        cursor = self.db.connection.cursor()
+        query = "DELETE FROM tblstudentinfo WHERE studentid = %s"
+        cursor.execute(query, (studentid,))
+        self.db.connection.commit()
+
+    def fetch_students(self, filters=None):
+        cursor = self.db.connection.cursor()
+        query = "SELECT * FROM tblstudentinfo WHERE studentid != 0"
+        params = []
+        if filters:
+            if filters.get("studentid"):
+                query += " AND studentid = %s"
+                params.append(filters["studentid"])
+            if filters.get("lastname"):
+                query += " AND lastname LIKE %s"
+                params.append(f"%{filters['lastname']}%")
+            if filters.get("firstname"):
+                query += " AND firstname LIKE %s"
+                params.append(f"%{filters['firstname']}%")
+        cursor.execute(query, tuple(params))
+        return cursor.fetchall()
+
+
+# -----------------------------
+# GUI View (Encapsulated with Tkinter)
+# -----------------------------
+class StudentApp(tk.Tk):
+    def __init__(self, controller: StudentController):
+        super().__init__()
+        self.controller = controller
+        self.title("Student Information System - OOP")
+        self.geometry("850x600")
+        self.create_widgets()
+        self.show_students()
+
+    def create_widgets(self):
+        labels = [
+            "Student ID",
+            "Last Name",
+            "First Name",
+            "Sex (M/F)",
+            "Contact Number",
+            "Email",
+        ]
+        self.entries = {}
+
+        for i, label in enumerate(labels):
+            tk.Label(self, text=label).grid(
+                row=i, column=0, padx=10, pady=5, sticky="w"
+            )
+            if label == "Sex (M/F)":
+                entry = ttk.Combobox(self, values=["M", "F"])
+            else:
+                entry = tk.Entry(self)
+            entry.grid(row=i, column=1, padx=10, pady=5)
+            self.entries[label] = entry
+
+        self.buttons = {
+            "Add": tk.Button(self, text="Add", command=self.add_student),
+            "Update": tk.Button(
+                self, text="Update", command=self.update_student, state=tk.DISABLED
+            ),
+            "Delete": tk.Button(
+                self, text="Delete", command=self.delete_student, state=tk.DISABLED
+            ),
+            "Search": tk.Button(self, text="Search", command=self.search_student),
+            "Clear": tk.Button(self, text="Clear", command=self.clear_entries),
+        }
+
+        for i, (text, btn) in enumerate(self.buttons.items(), start=5):
+            btn.grid(row=i, column=0 if i % 2 == 1 else 1, padx=10, pady=5)
+
+        columns = (
+            "Student ID",
+            "Last Name",
+            "First Name",
+            "Sex",
+            "Contact Number",
+            "Email",
+        )
+        self.tree = ttk.Treeview(self, columns=columns, show="headings")
+        for col in columns:
+            self.tree.heading(col, text=col)
+        self.tree.grid(row=10, column=0, columnspan=2, padx=10, pady=10)
+        self.tree.bind("<<TreeviewSelect>>", self.on_row_select)
+
+    def get_form_data(self):
+        return Student(
+            studentid=self.entries["Student ID"].get(),
+            lastname=self.entries["Last Name"].get(),
+            firstname=self.entries["First Name"].get(),
+            sex=self.entries["Sex (M/F)"].get().upper(),
+            contactnumber=self.entries["Contact Number"].get(),
+            email=self.entries["Email"].get(),
+        )
+
+    def add_student(self):
+        try:
+            student = self.get_form_data()
+            self.controller.add_student(student)
+            messagebox.showinfo("Success", "Student added successfully!")
+            self.show_students()
+            self.clear_entries()
+        except ValueError as ve:
+            messagebox.showerror("Input Error", str(ve))
+
+    def update_student(self):
+        try:
+            student = self.get_form_data()
+            self.controller.update_student(student)
+            messagebox.showinfo("Success", "Student updated successfully!")
+            self.show_students()
+            self.clear_entries()
+        except ValueError as ve:
+            messagebox.showerror("Update Error", str(ve))
+
+    def delete_student(self):
+        sid = self.entries["Student ID"].get()
+        if sid:
+            self.controller.delete_student(sid)
+            messagebox.showinfo("Success", "Student deleted successfully!")
+            self.show_students()
+            self.clear_entries()
+
+    def search_student(self):
+        filters = {
+            "studentid": self.entries["Student ID"].get(),
+            "lastname": self.entries["Last Name"].get(),
+            "firstname": self.entries["First Name"].get(),
+        }
+        results = self.controller.fetch_students(filters)
+        self.populate_tree(results)
+
+    def show_students(self):
+        results = self.controller.fetch_students()
+        self.populate_tree(results)
+
+    def populate_tree(self, data):
+        for row in self.tree.get_children():
+            self.tree.delete(row)
+        for row in data:
+            self.tree.insert("", tk.END, values=row)
+
+    def clear_entries(self):
+        for entry in self.entries.values():
+            entry.delete(0, tk.END)
+        self.entries["Sex (M/F)"].set("")
+        self.buttons["Add"].config(state=tk.NORMAL)
+        self.buttons["Update"].config(state=tk.DISABLED)
+        self.buttons["Delete"].config(state=tk.DISABLED)
+
+    def on_row_select(self, event):
+        selected = self.tree.selection()
+        if selected:
+            values = self.tree.item(selected[0])["values"]
+            fields = [
+                "Student ID",
+                "Last Name",
+                "First Name",
+                "Sex (M/F)",
+                "Contact Number",
+                "Email",
+            ]
+            for i, val in enumerate(values):
+                self.entries[fields[i]].delete(0, tk.END)
+                self.entries[fields[i]].insert(tk.END, val)
+            self.buttons["Add"].config(state=tk.DISABLED)
+            self.buttons["Update"].config(state=tk.NORMAL)
+            self.buttons["Delete"].config(state=tk.NORMAL)
+
+
+# -----------------------------
+# Application Entry Point
+# -----------------------------
+if __name__ == "__main__":
+    db = Database()
+    controller = StudentController(db)
+    app = StudentApp(controller)
+    app.mainloop()
+    db.close()
+```
+
+### Output
+
+<Image 
+  src="https://11j9kbjs2p.ufs.sh/f/UblXrSiF6MzLgutWNI0MJGKADRsFezmcPy6tpIhQUHk8uSax"
+  alt="student info gui"
+  width={1529}
+  height={790}
+/>
+
+<Callout>
+  The data above is sample data
+</Callout>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"fumadocs-ui": "^15.6.12",
 		"lucide-react": "^0.485.0",
 		"motion": "^12.7.2",
-		"next": "^15.4.6",
+		"next": "^15.5.2",
 		"next-themes": "^0.4.6",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",


### PR DESCRIPTION
This pull request introduces two new laboratory guides for student CRUD applications in Python, one for a console-based app and another for a GUI app using Tkinter. It also updates the dependencies for Next.js and improves the integration of Fumadocs UI components in the page rendering logic.

**New Lab Content:**

* Added `contents/itipt01/m-lab3.mdx` with a full guide for a Python console CRUD app using OOP and MySQL, including sample code, requirements, and expected output.
* Added `contents/itipt01/m-lab4.mdx` with a complete guide for a Python Tkinter GUI CRUD app, demonstrating OOP principles and providing code, output screenshot, and sample data callout.

**UI and Component Integration:**

* Improved the import organization and added `Callout` from `fumadocs-ui/components/callout` to the page component, making callouts available for MDX rendering. ([app/(labs)/[subject]/[slug]/page.tsxR13-L15](diffhunk://#diff-a3b818702c185f15a37173785e7e1a2c04a44777e8b9c4c2b3045d9ed6e1c83aR13-L15))
* Registered `Callout` as a custom component for MDX rendering in the page logic, enabling its use in new lab guides. ([app/(labs)/[subject]/[slug]/page.tsxR106](diffhunk://#diff-a3b818702c185f15a37173785e7e1a2c04a44777e8b9c4c2b3045d9ed6e1c83aR106))

**Dependency Update:**

* Updated the `next` package version from `15.4.6` to `15.5.2` in `package.json` for compatibility and improvements.